### PR TITLE
refactor: Improve CroppedSVG filtering logic

### DIFF
--- a/src/Components/CroppedSVG.ts
+++ b/src/Components/CroppedSVG.ts
@@ -51,13 +51,22 @@ class CroppedSVG {
 
     const result = [svg].reduce(flatten, []).filter((elem: SVGElement) => {
       const parentElement = elem.parentElement as HTMLElement;
+
+      const parentsTags: string[] = [];
+      let currentElement: HTMLElement | SVGElement = elem;
+
+      while (currentElement.parentElement && currentElement.parentElement.tagName) {
+        parentsTags.push(currentElement.parentElement.tagName);
+        currentElement = currentElement.parentElement;
+      }
+
       return (
         elem.tagName &&
         !invisibleElems.includes(elem.tagName) &&
         (elem.getBoundingClientRect().width ||
           elem.getBoundingClientRect().height) &&
         !parentElement.hasAttribute('mask') &&
-        parentElement.tagName !== 'defs' &&
+        parentsTags.indexOf('defs') === -1 &&
         (getComputedStyle(elem).stroke !== 'none' ||
           getComputedStyle(elem).fill !== 'none')
       );

--- a/src/Components/CroppedSVG.ts
+++ b/src/Components/CroppedSVG.ts
@@ -18,7 +18,12 @@ interface Coords {
 class CroppedSVG {
   coords: Coords;
 
-  constructor(public svg: SVGElement, public filename: string, public width?: number, public height?: number) {
+  constructor(
+    public svg: SVGElement,
+    public filename: string,
+    public width?: number,
+    public height?: number
+  ) {
     this.width = width;
     this.height = height;
     this.filename = filename;
@@ -52,11 +57,15 @@ class CroppedSVG {
     const result = [svg].reduce(flatten, []).filter((elem: SVGElement) => {
       const parentElement = elem.parentElement as HTMLElement;
 
-      const parentsTags: string[] = [];
+      let hasDefParent = false;
       let currentElement: HTMLElement | SVGElement = elem;
 
-      while (currentElement.parentElement && currentElement.parentElement.tagName) {
-        parentsTags.push(currentElement.parentElement.tagName);
+      while (currentElement.parentElement) {
+        if (currentElement.parentElement.tagName === 'defs') {
+          hasDefParent = true;
+          break;
+        }
+
         currentElement = currentElement.parentElement;
       }
 
@@ -66,7 +75,7 @@ class CroppedSVG {
         (elem.getBoundingClientRect().width ||
           elem.getBoundingClientRect().height) &&
         !parentElement.hasAttribute('mask') &&
-        parentsTags.indexOf('defs') === -1 &&
+        !hasDefParent &&
         (getComputedStyle(elem).stroke !== 'none' ||
           getComputedStyle(elem).fill !== 'none')
       );
@@ -141,7 +150,9 @@ class CroppedSVG {
     enhanceBtn.classList.add('EnhanceButton');
     enhanceBtn.addEventListener('click', handleImageEnhance);
     enhanceBtn.appendChild(this.svg);
-    const previewSectionElem = document.querySelector('.PreviewSection') as HTMLElement;
+    const previewSectionElem = document.querySelector(
+      '.PreviewSection'
+    ) as HTMLElement;
     previewSectionElem.appendChild(enhanceBtn);
   }
 


### PR DESCRIPTION
Hi! First of all, thanks for the tool. It is really awesome and helped me a lot with some projects, however, I noticed some edge cases for logos like this one:
`
<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 70.067">
  <defs>
    <clipPath id="b">
      <path d="M692.697 746H866.43v54.294H692.697V746z"/>
    </clipPath>
    <clipPath id="a">
      <path d="M706.23 757.475h145.453v33.224H706.23v-33.224z"/>
    </clipPath>
  </defs>
  <g clip-path="url(#a)" transform="matrix(2.04878 0 0 -2.04878 -1445.913 1620.972)">
    <path fill="#1d439c" d="M717.836 765.202c-2.386 0-4.58.817-6.318 2.187 2.022 4.564 6.142 10.687 11.76 16.667a10.204 10.204 0 0 0 4.773-8.643c0-1.554-.35-3.028-.971-4.347-1.782.825-3.444 1.857-4.854 3.16l3.078-5.778a10.182 10.182 0 0 0-7.468-3.246m-10.212 10.211c0 5.643 4.57 10.214 10.212 10.214 1.512 0 2.945-.329 4.239-.917-5.535-4.892-9.821-10.578-12.357-15.492a10.171 10.171 0 0 0-2.094 6.195m20.739-4.895a11.533 11.533 0 0 1 1.08 4.895c0 4.035-2.058 7.589-5.184 9.669a83.377 83.377 0 0 0 6.022 5.618 52.393 52.393 0 0 1-7.06-5.001 11.564 11.564 0 0 1-5.385 1.324c-6.41 0-11.606-5.2-11.606-11.61 0-2.893 1.06-5.543 2.813-7.573-2.224-4.809-2.613-8.671-.653-9.977 2.097-1.399 6.659 1.137 9.397 5.267 0 0-4.234-3.82-6.56-2.944-1.431.542-1.436 2.731-.256 5.87a11.549 11.549 0 0 1 6.865-2.249c3.18 0 6.06 1.278 8.157 3.348l.412-.776c5.059.411 20.164.811 20.164.811 0 .725-10.001.067-18.206 3.328"/>
  </g>
  <path fill="#1d439c" fill-rule="evenodd" d="M188.225 30.131l3.874-5.146-13.495-.005 3.325-4.408h13.496l3.884-5.145h-26.948l-18.537 24.6h26.952l3.87-5.15h-13.491l3.567-4.746h13.503zM206.94 15.427l-18.528 24.6h13.444l18.533-24.6h-13.448zM251.738 15.427l-9.391 12.471-2.89-12.47H228.95l-18.534 24.599h8.894l9.314-12.36 2.86 12.36h10.619l18.537-24.6h-8.902z"/>
  <g clip-path="url(#b)" transform="matrix(2.04878 0 0 -2.04878 -1445.913 1620.972)">
    <path fill="#1d439c" d="M850.074 783.657l-10.55.002a5.52 5.52 0 0 1-4.418-2.206l-5.445-7.227a1.609 1.609 0 0 1 1.283-2.576h10.548c1.807 0 3.412.866 4.422 2.206l1.308 1.735h1.524l1.905 2.53h-8.08l-2.55-3.384a1.428 1.428 0 0 0-1.147-.573h-1.857a.418.418 0 0 0-.42.418c0 .096.031.183.085.25l4.326 5.743c.261.35.677.571 1.146.571h1.86a.417.417 0 0 0 .332-.67l-.702-.933h6.556l1.16 1.541a1.61 1.61 0 0 1-1.286 2.573M777.155 780.476l-4.328-5.74a1.425 1.425 0 0 0-1.146-.572h-1.859a.42.42 0 1 0-.333.668l4.326 5.741c.265.345.68.573 1.147.573h1.86a.417.417 0 0 0 .333-.67m7.334 1.573c0 .887-.718 1.608-1.608 1.608h-10.543a5.524 5.524 0 0 1-4.422-2.204l-5.446-7.227a1.608 1.608 0 0 1 1.284-2.576h10.545c1.809 0 3.414.866 4.424 2.206l5.445 7.226c.202.268.321.602.321.967M757.11 780.476l-.692-.916a1.438 1.438 0 0 0-1.147-.568l-2.695.002 1.625 2.152h2.574a.419.419 0 0 0 .335-.67m-3.519-4.665l-.812-1.077a1.43 1.43 0 0 0-1.146-.57h-2.693l1.743 2.316h2.576a.417.417 0 0 0 .332-.669m6.092 1.55a5.515 5.515 0 0 1 3.189 2.065l1.247 1.656a1.608 1.608 0 0 1-1.283 2.575h-13.307l-9.046-12.007h13.768c1.809 0 3.413.866 4.423 2.206l1.276 1.694a1.295 1.295 0 0 1-.267 1.811"/>
  </g>
</svg>
`

As you can see, the two first `path` tags have a higher parent `defs` but this is not detected with the current logic, so I added a change for checking any `defs` tag parent.